### PR TITLE
bring in hal ldflags in order to be linkabe against udc hal

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,5 @@
 rootPath = ./
+rootDir = ./
 include ./include.mk
 
 libSources = src/*.cpp

--- a/include.mk
+++ b/include.mk
@@ -10,7 +10,7 @@ cactusRootPath=${rootPath}/../../
 halRootPath=${rootPath}/../hal
 halPath=${halRootPath}/lib
 
-include  ${sonLibRootDir}/include.mk
+include ${halRootPath}/include.mk
 ifeq (${CXX_ABI_DEF},)
     CXX_ABI_DEF = -D_GLIBCXX_USE_CXX11_ABI=1
 endif
@@ -19,8 +19,9 @@ incls = -I ${sonLibDir} -I ${cactusRootPath}/api/inc -I ${halPath} ${tokyoCabine
 
 CFLAGS += ${incls}
 CXXFLAGS += ${incls} -D__STDC_LIMIT_MACROS -Wno-deprecated -std=c++11 -Wno-sign-compare
-LDLIBS = ${halPath}/halLib.a ${sonLibDir}/sonLib.a ${sonLibDir}/cuTest.a 
-LIBDEPENDS = ${LDLIBS}
+LIBDEPENDS = ${halPath}/halLib.a ${sonLibDir}/sonLib.a ${sonLibDir}/cuTest.a 
+LDLIBS_HAL = ${LIBDEPENDS} ${LDLIBS}
+LDLIBS := ${LDLIBS_HAL}
 
 # hdf5 compilation is done through its wrappers.
 # we can speficy our own (sonlib) compilers with these variables:


### PR DESCRIPTION
This is needed ex to build cactus with a udc-enabled hal. 